### PR TITLE
Changed shader loading

### DIFF
--- a/common/com/sirolf2009/necromancy/Necromancy.java
+++ b/common/com/sirolf2009/necromancy/Necromancy.java
@@ -3,21 +3,16 @@ package com.sirolf2009.necromancy;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 import java.util.logging.Logger;
 
-import org.lwjgl.opengl.ARBFragmentShader;
 import org.lwjgl.opengl.ARBShaderObjects;
-import org.lwjgl.opengl.ARBVertexShader;
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL20;
 
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.server.dedicated.PropertyManager;
@@ -79,19 +74,6 @@ public class Necromancy {
     public void preInit(FMLPreInitializationEvent event) {
         loggerNecromancy = Logger.getLogger("necromancy");
         loggerNecromancy.setParent(FMLLog.getLogger());
-        
-        try {
-        	int vertShader = loadShader("assets/necromancy/shaders/scent/scentFragment.shader",GL20.GL_VERTEX_SHADER);
-			int fragShader = loadShader("assets/necromancy/shaders/scent/scentVertex.shader",GL20.GL_FRAGMENT_SHADER);
-			int scentProgram = GL20.glCreateProgram();
-			GL20.glAttachShader(scentProgram, vertShader);
-			GL20.glAttachShader(scentProgram, fragShader);
-			GL20.glLinkProgram(scentProgram);
-			GL20.glValidateProgram(scentProgram);
-		} catch (Exception e1) {
-			e1.printStackTrace();
-    		System.exit(-1);
-		}
 
         ConfigurationNecromancy.initProperties(event);
 
@@ -154,34 +136,6 @@ public class Necromancy {
         villageComponentsList.add(PacketHandler.class);
 
         GameRegistry.registerWorldGenerator(new WorldGenerator());
-    }
-    
-    public int loadShader(String filename, int type) {
-    	StringBuilder shaderSource = new StringBuilder();
-    	int shaderID = 0;
-    	
-    	try {
-    		BufferedReader reader = new BufferedReader(new FileReader(getClass().getClassLoader().getResource(filename).toURI().getPath()));
-    		String line;
-    		while ((line = reader.readLine()) != null) {
-    			shaderSource.append(line).append("\n");
-    		}
-    		reader.close();
-    	} catch (IOException e) {
-    		System.err.println("Could not read file.");
-    		e.printStackTrace();
-    		System.exit(-1);
-    	} catch (URISyntaxException e) {
-    		System.err.println("Could not read file.");
-    		e.printStackTrace();
-    		System.exit(-1);
-		}
-    	
-    	shaderID = GL20.glCreateShader(type);
-    	GL20.glShaderSource(shaderID, shaderSource);
-    	GL20.glCompileShader(shaderID);
-    	
-    	return shaderID;
     }
     
     private int createShader(String filename, int shaderType) throws Exception {


### PR DESCRIPTION
Hi,

I was creating a collection of mods for my friends and me with 1.6.2 mods, but Necromancy crashed server side. I moved the shader loading to the ClientProx with SideOnly annotations.

It worked server side but the client was crashing now. The file to open in the loadShader method kept returning null as filename, assumably because it's somewhere deeper in the package? So I changed the path to be absolute, starting in the root folder. It eh seems to work now, I hope.
